### PR TITLE
changed mac shortcut because of conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # browser-refresh package
 
-Reloads browser from within the atom editor using keyboard shortcut `f5` or `cmd-shift-s`. Tested on **mac** and **linux**.
+Reloads browser from within the atom editor using keyboard shortcut `f5` or `alt-shift-cmd-s`. Tested on **mac** and **linux**.
 
 On Mac OSX, Chrome and Chrome Canary can refresh without stealing focus (optional). Firefox and Safari will steal the focus.
 

--- a/keymaps/browser-refresh.cson
+++ b/keymaps/browser-refresh.cson
@@ -8,5 +8,5 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
-  'shift-cmd-s' : 'browser-refresh:open'
+  'alt-shift-cmd-s' : 'browser-refresh:open'
   'f5'          : 'browser-refresh:open'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.7.0",
+  "version": "0.6.4",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Both alt-cmd-s and shift-cmd-s was conflicting with default atom shortcuts. So i changed it to shift-alt-cmd-s.
