### PR TITLE
Add FF versions Devs use

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Commands to refresh browsers are taken from [sublime plugin](https://github.com/
 - Chrome
 - Chrome Canary
 - Firefox
+- Firefox Nightly
+- Firefox Developer Edition
 - Safari (Mac only)

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -37,6 +37,26 @@ delay 0.2
 activate application a
 """
 
+MacFirefoxNightlyCmd = """
+set a to path to frontmost application as text
+tell application "FirefoxNightly"
+	activate
+	tell application "System Events" to keystroke "r" using command down
+end tell
+delay 0.2
+activate application a
+"""
+
+MacFirefoxDeveloperEditionCmd = """
+set a to path to frontmost application as text
+tell application "FirefoxDeveloperEdition"
+	activate
+	tell application "System Events" to keystroke "r" using command down
+end tell
+delay 0.2
+activate application a
+"""
+
 MacSafariCmd = """
 tell application "Safari"
   activate
@@ -49,6 +69,8 @@ end tell
 Commands = {
   darwin: {
     firefox      : MacFirefoxCmd,
+    firefoxNightly : MacFirefoxNightlyCmd,
+    firefoxDeveloperEdition : MacFirefoxDeveloperEditionCmd,
     chrome       : MacChromeCmd,
     chromeCanary : MacChromeCanaryCmd,
     safari       : MacSafariCmd
@@ -110,6 +132,10 @@ BrowserOpen = ()->
     atom.workspace.saveAll()
   if(atom.config.get 'browser-refresh.firefox')
     RunCmd('firefox')
+  if(atom.config.get 'browser-refresh.firefoxNightly')
+    RunCmd('firefoxNightly')
+  if(atom.config.get 'browser-refresh.firefoxDeveloperEdition')
+    RunCmd('firefoxDeveloperEdition')
   if(atom.config.get 'browser-refresh.googleChrome')
     RunCmd('chrome')
   if(atom.config.get 'browser-refresh.googleChromeCanary')

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -12,6 +12,8 @@ module.exports =
     googleChrome            : true
     firefox                 : false
     safari                  : false
+    firefoxNightly          : false
+    firefoxDeveloperEdition : true
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()


### PR DESCRIPTION
Just like the title says; PR adds the ff nightly and dev-edition (née Aurora) branches which aren't currently supported.

Didn't bump the version though...
