### PR TITLE
Option to wait between save and refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reloads browser from within the atom editor using keyboard shortcut `f5` or `cmd-shift-s`. Tested on **mac** and **linux**.
 
-On Mac OSX, Chrome and Chrome Canary reload works without stealing focus. Firefox and Safari will steal the focus though.
+On Mac OSX, Chrome and Chrome Canary can refresh without stealing focus (optional). Firefox and Safari will steal the focus.
 
 On Linux, you need to install `xdotool`. `sudo apt-get install xdotool` on ubuntu.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # browser-refresh package
 
-Reloads browser from within the atom editor using keyboard shortcut `f5`. Tested on **mac** and **linux**.
+Reloads browser from within the atom editor using keyboard shortcut `f5` or `cmd-shift-s`. Tested on **mac** and **linux**.
 
 On Mac, Chrome reload works without stealing focus. Firefox and Safari will steal the focus though.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # browser-refresh package
 
-Reloads browser from within the atom editor using keyboard shortcut `f5` or `cmd-shift-s`. Tested on **mac** and **linux**.
+Reloads browser from within the atom editor using keyboard shortcut `f5` or `alt-shift-cmd-s`. Tested on **mac** and **linux**.
 
 On Mac OSX, Chrome and Chrome Canary can refresh without stealing focus (optional). Firefox and Safari will steal the focus.
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Commands to refresh browsers are taken from [sublime plugin](https://github.com/
 - Chrome
 - Chrome Canary
 - Firefox
+- Firefox Nightly
+- Firefox Developer Edition
 - Safari (Mac only)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reloads browser from within the atom editor using keyboard shortcut `f5` or `cmd-shift-s`. Tested on **mac** and **linux**.
 
-On Mac, Chrome reload works without stealing focus. Firefox and Safari will steal the focus though.
+On Mac OSX, Chrome and Chrome Canary reload works without stealing focus. Firefox and Safari will steal the focus though.
 
 On Linux, you need to install `xdotool`. `sudo apt-get install xdotool` on ubuntu.
 
@@ -11,5 +11,6 @@ Commands to refresh browsers are taken from [sublime plugin](https://github.com/
 ## Supported browsers
 
 - Chrome
+- Chrome Canary
 - Firefox
 - Safari (Mac only)

--- a/keymaps/browser-refresh.cson
+++ b/keymaps/browser-refresh.cson
@@ -8,5 +8,5 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
-  'shift-cmd-s' : 'browser-refresh:open'
+  'alt-shift-cmd-s' : 'browser-refresh:open'
   'f5'          : 'browser-refresh:open'

--- a/keymaps/browser-refresh.cson
+++ b/keymaps/browser-refresh.cson
@@ -8,4 +8,5 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
-  'f5': 'browser-refresh:open'
+  'shift-cmd-s' : 'browser-refresh:open'
+  'f5'          : 'browser-refresh:open'

--- a/keymaps/browser-refresh.cson
+++ b/keymaps/browser-refresh.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'alt-shift-cmd-s' : 'browser-refresh:open'
   'f5'          : 'browser-refresh:open'

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -37,6 +37,26 @@ delay 0.2
 activate application a
 """
 
+MacFirefoxNightlyCmd = """
+set a to path to frontmost application as text
+tell application "FirefoxNightly"
+	activate
+	tell application "System Events" to keystroke "r" using command down
+end tell
+delay 0.2
+activate application a
+"""
+
+MacFirefoxDeveloperEditionCmd = """
+set a to path to frontmost application as text
+tell application "FirefoxDeveloperEdition"
+	activate
+	tell application "System Events" to keystroke "r" using command down
+end tell
+delay 0.2
+activate application a
+"""
+
 MacSafariCmd = """
 tell application "Safari"
   activate
@@ -49,6 +69,8 @@ end tell
 Commands = {
   darwin: {
     firefox      : MacFirefoxCmd,
+    firefoxNightly : MacFirefoxNightlyCmd,
+    firefoxDeveloperEdition : MacFirefoxDeveloperEditionCmd,
     chrome       : MacChromeCmd,
     chromeCanary : MacChromeCanaryCmd,
     safari       : MacSafariCmd
@@ -110,6 +132,10 @@ BrowserOpen = ()->
     atom.workspace.saveAll()
   if(atom.config.get 'browser-refresh.firefox')
     RunCmd('firefox')
+  if(atom.config.get 'browser-refresh.firefoxNightly')
+    RunCmd('firefoxNightly')
+  if(atom.config.get 'browser-refresh.firefoxDeveloperEdition')
+    RunCmd('firefoxDeveloperEdition')
   if(atom.config.get 'browser-refresh.googleChrome')
     RunCmd('chrome')
   if(atom.config.get 'browser-refresh.googleChromeCanary')

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -2,8 +2,15 @@
 OS = require 'os'
 StatusView = require './status-view'
 
+MacChromeActivation = atom.config.get 'browser-refresh.chromeBackgroundRefresh'
+if (MacChromeActivation == false)
+  MacChromeActivation = "activate"
+else
+  MacChromeActivation = ""
+
 MacChromeCmd = """
 tell application "Google Chrome"
+  #{MacChromeActivation}
   "chrome"
   set winref to a reference to (first window whose title does not start with "Developer Tools - ")
   set winref's index to 1
@@ -12,7 +19,8 @@ end tell
 """
 MacChromeCanaryCmd = """
 tell application "Google Chrome Canary"
-  "chromeCanary"
+  #{MacChromeActivation}
+  "chrome canary"
   set winref to a reference to (first window whose title does not start with "Developer Tools - ")
   set winref's index to 1
   reload active tab of winref
@@ -46,8 +54,26 @@ Commands = {
     safari       : MacSafariCmd
   },
   linux: {
-    firefox: ['search', '--sync', '--onlyvisible', '--class', 'firefox', 'key', 'F5', 'windowactivate'],
-    chrome: ['search', '--sync', '--onlyvisible', '--class', 'chrome', 'key', 'F5', 'windowactivate']
+    firefox: [
+      'search',
+      '--sync',
+      '--onlyvisible',
+      '--class',
+      'firefox',
+      'key',
+      'F5',
+      'windowactivate'
+    ],
+    chrome: [
+      'search',
+      '--sync',
+      '--onlyvisible',
+      '--class',
+      'chrome',
+      'key',
+      'F5',
+      'windowactivate'
+    ]
   }
 }
 

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -10,7 +10,14 @@ tell application "Google Chrome"
   reload active tab of winref
 end tell
 """
-
+MacChromeCanaryCmd = """
+tell application "Google Chrome Canary"
+  "chromeCanary"
+  set winref to a reference to (first window whose title does not start with "Developer Tools - ")
+  set winref's index to 1
+  reload active tab of winref
+end tell
+"""
 
 MacFirefoxCmd = """
 set a to path to frontmost application as text
@@ -33,9 +40,10 @@ end tell
 
 Commands = {
   darwin: {
-    firefox: MacFirefoxCmd,
-    chrome: MacChromeCmd,
-    safari: MacSafariCmd
+    firefox      : MacFirefoxCmd,
+    chrome       : MacChromeCmd,
+    chromeCanary : MacChromeCanaryCmd,
+    safari       : MacSafariCmd
   },
   linux: {
     firefox: ['search', '--sync', '--onlyvisible', '--class', 'firefox', 'key', 'F5', 'windowactivate'],
@@ -78,6 +86,8 @@ BrowserOpen = ()->
     RunCmd('firefox')
   if(atom.config.get 'browser-refresh.googleChrome')
     RunCmd('chrome')
+  if(atom.config.get 'browser-refresh.googleChromeCanary')
+    RunCmd('chromeCanary')
   if(atom.config.get 'browser-refresh.safari')
     RunCmd('safari')
 

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -138,17 +138,20 @@ BrowserOpen = ()->
     atom.workspace.getActiveEditor().save()
   if(atom.config.get 'browser-refresh.saveFilesBeforeRefresh')
     atom.workspace.saveAll()
-  if(atom.config.get 'browser-refresh.firefox')
-    RunCmd('firefox')
-  if(atom.config.get 'browser-refresh.firefoxNightly')
-    RunCmd('firefoxNightly')
-  if(atom.config.get 'browser-refresh.firefoxDeveloperEdition')
-    RunCmd('firefoxDeveloperEdition')
-  if(atom.config.get 'browser-refresh.googleChrome')
-    RunCmd('chrome')
-  if(atom.config.get 'browser-refresh.googleChromeCanary')
-    RunCmd('chromeCanary')
-  if(atom.config.get 'browser-refresh.safari')
-    RunCmd('safari')
+
+  setTimeout ->
+    if(atom.config.get 'browser-refresh.firefox')
+      RunCmd('firefox')
+    if(atom.config.get 'browser-refresh.firefoxNightly')
+      RunCmd('firefoxNightly')
+    if(atom.config.get 'browser-refresh.firefoxDeveloperEdition')
+      RunCmd('firefoxDeveloperEdition')
+    if(atom.config.get 'browser-refresh.googleChrome')
+      RunCmd('chrome')
+    if(atom.config.get 'browser-refresh.googleChromeCanary')
+      RunCmd('chromeCanary')
+    if(atom.config.get 'browser-refresh.safari')
+      RunCmd('safari')
+  , atom.config.get 'browser-refresh.waitMillisecondsBetweenSaveAndRefresh'
 
 module.exports = BrowserOpen

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -11,11 +11,15 @@ tell application "Google Chrome"
 end tell
 """
 
+
 MacFirefoxCmd = """
+set a to path to frontmost application as text
 tell application "Firefox"
-  activate
-  tell application "System Events" to keystroke "r" using command down
+	activate
+	tell application "System Events" to keystroke "r" using command down
 end tell
+delay 0.2
+activate application a
 """
 
 MacSafariCmd = """
@@ -66,6 +70,8 @@ RunCmd = (browser) ->
 
 
 BrowserOpen = ()->
+  if(atom.config.get 'browser-refresh.saveFileBeforeRefresh')
+    atom.workspace.getActiveEditor().save()
   if(atom.config.get 'browser-refresh.firefox')
     RunCmd('firefox')
   if(atom.config.get 'browser-refresh.googleChrome')

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -39,7 +39,7 @@ Commands = {
   },
   linux: {
     firefox: ['search', '--sync', '--onlyvisible', '--class', 'firefox', 'key', 'F5', 'windowactivate'],
-    chrome: ['search', '--sync', '--onlyvisible', '--class', 'firefox', 'key', 'F5', 'windowactivate']
+    chrome: ['search', '--sync', '--onlyvisible', '--class', 'chrome', 'key', 'F5', 'windowactivate']
   }
 }
 
@@ -70,6 +70,8 @@ RunCmd = (browser) ->
 
 
 BrowserOpen = ()->
+  if(atom.config.get 'browser-refresh.saveCurrentFileBeforeRefresh')
+    atom.workspace.getActiveEditor().save()
   if(atom.config.get 'browser-refresh.saveFilesBeforeRefresh')
     atom.workspace.saveAll()
   if(atom.config.get 'browser-refresh.firefox')

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -70,8 +70,8 @@ RunCmd = (browser) ->
 
 
 BrowserOpen = ()->
-  if(atom.config.get 'browser-refresh.saveFileBeforeRefresh')
-    atom.workspace.getActiveEditor().save()
+  if(atom.config.get 'browser-refresh.saveFilesBeforeRefresh')
+    atom.workspace.saveAll()
   if(atom.config.get 'browser-refresh.firefox')
     RunCmd('firefox')
   if(atom.config.get 'browser-refresh.googleChrome')

--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -99,12 +99,22 @@ Commands = {
   }
 }
 
+OpenPanel = (params) ->
+  statusView = new StatusView(params)
+  statusPanel = atom.workspace.addBottomPanel(item: statusView)
+  setTimeout ->
+    statusView?.destroy()
+    statusView = null
+    statusPanel?.destroy()
+    statusPanel = null
+  , 2000
+
 RunMacCmd = (BrowserCmd) ->
   new BufferedProcess({
     command: 'osascript'
     args: ['-e', BrowserCmd]
     stderr: (data) ->
-      new StatusView(type: 'alert', message: data.toString())
+      OpenPanel(type: 'alert', message: data.toString())
   })
 
 RunLinuxCmd = (BrowserArgs) ->
@@ -112,9 +122,8 @@ RunLinuxCmd = (BrowserArgs) ->
     command: 'xdotool'
     args: BrowserArgs
     stderr: (data) ->
-      new StatusView(type: 'alert', message: data.toString())
+      OpenPanel(type: 'alert', message: data.toString())
   })
-
 
 RunCmd = (browser) ->
   if OS.platform() == 'darwin'
@@ -122,8 +131,7 @@ RunCmd = (browser) ->
   else if OS.platform() == 'linux' and browser isnt 'safari'
     RunLinuxCmd(Commands['linux'][browser])
   else
-    new StatusView(type: 'alert', message: 'Unsupported platform')
-
+    OpenPanel(type: 'alert', message: 'Unsupported platform')
 
 BrowserOpen = ()->
   if(atom.config.get 'browser-refresh.saveCurrentFileBeforeRefresh')

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -6,11 +6,12 @@ BrowserOpen = require "./browser-open"
 module.exports =
 
   configDefaults:
-    googleChromeCanary     : true
-    googleChrome           : true
-    firefox                : false
-    safari                 : false
-    saveFilesBeforeRefresh : false
+    saveFilesBeforeRefresh  : false
+    chromeBackgroundRefresh : true
+    googleChromeCanary      : true
+    googleChrome            : true
+    firefox                 : false
+    safari                  : false
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -27,6 +27,9 @@ module.exports =
     firefoxDeveloperEdition:
       type: 'boolean'
       default: false
+    waitMillisecondsBetweenSaveAndRefresh:
+      type: 'number'
+      default: 0
 
   activate: (state) ->
     atom.commands.add 'atom-workspace', 'browser-refresh:open': ->

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -6,10 +6,11 @@ BrowserOpen = require "./browser-open"
 module.exports =
 
   configDefaults:
-    googleChrome: true
-    firefox: false
-    safari: false
-    saveFilesBeforeRefresh: false
+    googleChromeCanary     : true
+    googleChrome           : true
+    firefox                : false
+    safari                 : false
+    saveFilesBeforeRefresh : false
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -9,7 +9,7 @@ module.exports =
     googleChrome: true
     firefox: false
     safari: false
-    saveFileBeforeRefresh: false
+    saveFilesBeforeRefresh: false
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -9,6 +9,7 @@ module.exports =
     googleChrome: true
     firefox: false
     safari: false
+    saveFileBeforeRefresh: false
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -1,6 +1,5 @@
 
 BrowserOpen = require "./browser-open"
-{$, $$, View, EditorView} = require 'atom'
 
 
 module.exports =

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -1,21 +1,36 @@
 
 BrowserOpen = require "./browser-open"
 
-
 module.exports =
-
-  configDefaults:
-    saveFilesBeforeRefresh  : false
-    chromeBackgroundRefresh : true
-    googleChromeCanary      : false
-    googleChrome            : true
-    firefox                 : false
-    safari                  : false
-    firefoxNightly          : false
-    firefoxDeveloperEdition : false
+  config:
+    saveFilesBeforeRefresh:
+      type: 'boolean'
+      default: false
+    chromeBackgroundRefresh:
+      type: 'boolean'
+      default: true
+    googleChromeCanary:
+      type: 'boolean'
+      default: false
+    googleChrome:
+      type: 'boolean'
+      default: true
+    firefox:
+      type: 'boolean'
+      default: false
+    safari:
+      type: 'boolean'
+      default: false
+    firefoxNightly:
+      type: 'boolean'
+      default: false
+    firefoxDeveloperEdition:
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
-    atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()
+    atom.commands.add 'atom-workspace', 'browser-refresh:open': ->
+      BrowserOpen()
 
   deactivate: ->
 

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -12,6 +12,8 @@ module.exports =
     googleChrome            : true
     firefox                 : false
     safari                  : false
+    firefoxNightly          : false
+    firefoxDeveloperEdition : true
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -8,12 +8,12 @@ module.exports =
   configDefaults:
     saveFilesBeforeRefresh  : false
     chromeBackgroundRefresh : true
-    googleChromeCanary      : true
+    googleChromeCanary      : false
     googleChrome            : true
     firefox                 : false
     safari                  : false
     firefoxNightly          : false
-    firefoxDeveloperEdition : true
+    firefoxDeveloperEdition : false
 
   activate: (state) ->
     atom.workspaceView.command "browser-refresh:open", -> BrowserOpen()

--- a/lib/status-view.coffee
+++ b/lib/status-view.coffee
@@ -1,13 +1,9 @@
-{View} = require 'atom'
+{View} = require 'atom-space-pen-views'
 
 module.exports =
   class StatusView extends View
     @content = (params) ->
-      @div class: 'browser-refresh overlay from-bottom', =>
-        @div class: "#{params.type} message", params.message
+      @div class: 'browser-refresh-view', =>
+        @div class: "type-#{params.type}", 'Browser Refresh: ' + params.message
 
-    initialize: ->
-      atom.workspaceView.append(this)
-      setTimeout =>
-        @detach()
-      , 2000
+    destroy: ->

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "dist": {
     "shasum": "7162bc46a64a5c52616ac006aced47e7a1a85080"
   },
-  "_from": "/var/folders/1q/3sx49k4165d5j_57156fl8700000gp/T/d-114419-57393-vdq60p/package.tgz"
+  "_from": "/var/folders/1q/3sx49k4165d5j_57156fl8700000gp/T/d-114419-57393-vdq60p/package.tgz",
+  "dependencies": {
+    "atom-space-pen-views": "^2.0.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.7.0",
+  "version": "0.6.4",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh",
   "main": "./lib/browser-refresh",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Refresh browser from atom editor",
   "repository": {
     "type": "git",

--- a/styles/browser-refresh.less
+++ b/styles/browser-refresh.less
@@ -4,21 +4,14 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.browser-refresh {
-  .alert {
+.browser-refresh-view {
+  padding: 15px;
+  font-weight: bold;
+
+  .type-alert {
     color: @text-color-warning;
   }
-  .success {
+  .type-success {
     color: @text-color-success;
-  }
-}
-
-.browser-refresh.overlay {
-  width: 600px;
-}
-
-.browser-refresh {
-  .info-view {
-    overflow: auto;
   }
 }


### PR DESCRIPTION
I have a gulp watch task that automatically builds files on change. I had an issue where the build tasks were sometimes not completed before browser refresh. This pull request adds an option to delay between save and refresh, to solve that for me.
