### PR TITLE
Activate browser config across all selected browsers (close #21)

### DIFF
--- a/lib/browser-open.coffee
+++ b/lib/browser-open.coffee
@@ -2,24 +2,23 @@
 OS = require 'os'
 StatusView = require './status-view'
 
-MacChromeActivation = atom.config.get 'browser-refresh.chromeBackgroundRefresh'
-if (MacChromeActivation == false)
-  MacChromeActivation = "activate"
-else
-  MacChromeActivation = ""
+activate = false
+if atom.config.get('browser-refresh.chromeBackgroundRefresh') or atom.config.get('browser-refresh.activateBrowser')
+  activate = true
 
 MacChromeCmd = """
 tell application "Google Chrome"
-  #{MacChromeActivation}
+  #{if activate then 'activate' else ''}
   "chrome"
   set winref to a reference to (first window whose title does not start with "Developer Tools - ")
   set winref's index to 1
   reload active tab of winref
 end tell
 """
+
 MacChromeCanaryCmd = """
 tell application "Google Chrome Canary"
-  #{MacChromeActivation}
+  #{if activate then 'activate' else ''}
   "chrome canary"
   set winref to a reference to (first window whose title does not start with "Developer Tools - ")
   set winref's index to 1
@@ -33,8 +32,7 @@ tell application "Firefox"
 	activate
 	tell application "System Events" to keystroke "r" using command down
 end tell
-delay 0.2
-activate application a
+#{if activate then '' else 'delay 0.2\nactivate application a'}
 """
 
 MacFirefoxNightlyCmd = """
@@ -43,8 +41,7 @@ tell application "FirefoxNightly"
 	activate
 	tell application "System Events" to keystroke "r" using command down
 end tell
-delay 0.2
-activate application a
+#{if activate then '' else 'delay 0.2\nactivate application a'}
 """
 
 MacFirefoxDeveloperEditionCmd = """
@@ -53,13 +50,12 @@ tell application "FirefoxDeveloperEdition"
 	activate
 	tell application "System Events" to keystroke "r" using command down
 end tell
-delay 0.2
-activate application a
+#{if activate then '' else 'delay 0.2\nactivate application a'}
 """
 
 MacSafariCmd = """
 tell application "Safari"
-  activate
+  #{if activate then 'activate' else ''}
   tell its first document
     set its URL to (get its URL)
   end tell

--- a/lib/browser-refresh.coffee
+++ b/lib/browser-refresh.coffee
@@ -27,6 +27,9 @@ module.exports =
     firefoxDeveloperEdition:
       type: 'boolean'
       default: false
+    activateBrowser:
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     atom.commands.add 'atom-workspace', 'browser-refresh:open': ->


### PR DESCRIPTION
Use `activateBrowser` config to activate after refresh. Could potentially remove `chromeBackgroundRefresh` now, which is targeted a single browser.

> **Since a lot of people are using this package, but maintenance seems halted. I would strongly recommend @raviraa giving one of us collaborator rights to close some of the open issues.**